### PR TITLE
Fix i18n issues

### DIFF
--- a/ets_question_answer.php
+++ b/ets_question_answer.php
@@ -9,7 +9,7 @@
  * Requires at least: 5.6
  * WC tested up to: 8.1
  * Requires PHP: 7.0
- * Text Domain: ets_q_n_a
+ * Text Domain: product-questions-answers-for-woocommerce
  * Domain Path: /languages
  */   
  
@@ -28,8 +28,8 @@ class ETS_WOO_PRODUCT_QUESTION_ANSWER {
 	}  
 
 	public function qa_load_local() {
-		$localeDir = dirname(plugin_dir_path( __FILE__ ) ) . '/question-answer-plugin-by-ets/languages/ets_q_n_a-'.get_locale() .'.mo';
-        $res = load_textdomain( 'ets_q_n_a', $localeDir );   
+		$localeDir = dirname(plugin_dir_path( __FILE__ ) ) . '/question-answer-plugin-by-ets/languages/product-questions-answers-for-woocommerce-'.get_locale() .'.mo';
+        $res = load_textdomain( 'product-questions-answers-for-woocommerce', $localeDir );   
     }
 
     public function declare_hpos_compatibility(){

--- a/includes/ets_admin_qa_function.php
+++ b/includes/ets_admin_qa_function.php
@@ -46,7 +46,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 	 * Add new Theam option in the admin Panel
 	 */ 
 	public function admin_menu_product_qa(){
-		add_menu_page(__('Products Q & A','ets_q_n_a'), __('Products Q & A','ets_q_n_a'), 'manage_options', 'theme-options', array($this, 'etsLoadMoreQa'), 'dashicons-info ',59);
+		add_menu_page(__('Products Q & A','product-questions-answers-for-woocommerce'), __('Products Q & A','product-questions-answers-for-woocommerce'), 'manage_options', 'theme-options', array($this, 'etsLoadMoreQa'), 'dashicons-info ',59);
 	}
 
 
@@ -55,7 +55,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 	 */
 	public function etsErrorNotification() { 
 		$class = 'notice notice-error';
-		$message = __( 'Access not allowed', 'ets_q_n_a' ).'.';
+		$message = __( 'Access not allowed', 'product-questions-answers-for-woocommerce' ).'.';
 
 		printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) ); 
 	} 
@@ -69,7 +69,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 		if(empty($loadButton)){  	
 			update_option( 'ets_load_more_button','true' );
 			update_option( 'ets_product_q_qa_list_length', '10' );
-			update_option( 'ets_load_more_button_name', __("Load More",'ets_q_n_a') );
+			update_option( 'ets_load_more_button_name', __("Load More",'product-questions-answers-for-woocommerce') );
 			update_option( 'ets_product_qa_paging_type', "normal" );
 			$loadButton = get_option( 'ets_load_more_button' );
 
@@ -105,7 +105,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 						if(!empty($buttonName)){
 							update_option( 'ets_load_more_button_name', $buttonName );
 						} else {
-							$buttonName = __("Load More",'ets_q_n_a');
+							$buttonName = __("Load More",'product-questions-answers-for-woocommerce');
 							update_option( 'ets_load_more_button_name', $buttonName );
 						} 
 					} else {
@@ -113,7 +113,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 						update_option( 'ets_product_q_qa_list_length', $lengthOfList );
 					}
 				} else {
-					$buttonName = __("Load More",'ets_q_n_a');		
+					$buttonName = __("Load More",'product-questions-answers-for-woocommerce');		
 					update_option( 'ets_load_more_button', $loadButton );
 					update_option( 'ets_product_q_qa_list_length', $lengthOfList );
 					update_option( 'ets_load_more_button_name', $buttonName );
@@ -127,39 +127,39 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 		
 		
 		?><div class="wrap"><div id="icon-options-general" class="icon32"><br></div>
-		<h2><?php echo __("Product Q & A Setting",'ets_q_n_a'); ?></h2></div>
+		<h2><?php echo __("Product Q & A Setting",'product-questions-answers-for-woocommerce'); ?></h2></div>
 		<form method="post" name="load_more_form" action="#"> 
 			 	
 			<table>
 				<tr>
-					<td><h4><?php echo __('Load More','ets_q_n_a'); ?>: </h4></td>
+					<td><h4><?php echo __('Load More','product-questions-answers-for-woocommerce'); ?>: </h4></td>
 					<td> 
 						 <?php wp_nonce_field( 'etsLoadMoreQa', 'ets_load_more_button' ); ?>
 						<input type="checkbox" <?php if(($loadButton == 1)) { echo $loadButton; ?> checked <?php }?> name="ets_load_more_active" value="1" >
 					</td> 	
 				</tr> 
 				<tr>
-					<td><h4><?php echo __('Page Size','ets_q_n_a'); ?>: </h4></td>
+					<td><h4><?php echo __('Page Size','product-questions-answers-for-woocommerce'); ?>: </h4></td>
 					<td><input type="number" name="ets_length_of_list" value="<?php echo isset($lengthOfList) ? $lengthOfList : '';?>"  min="1"  ></td>
 				</tr> 
 				<tr>
-					<td><h4><?php echo __('Paging Button Name','ets_q_n_a'); ?>: </h4></td>
+					<td><h4><?php echo __('Paging Button Name','product-questions-answers-for-woocommerce'); ?>: </h4></td>
 					<td><input type="text" name="ets_load_more_button_name" value="<?php echo isset($buttonName) ? $buttonName : '';?>" width="50px" height="90px"></td>
 				</tr>
 				<tr>
-					<td><h4><?php echo __('Layout','ets_q_n_a'); ?>: </h4></td>
+					<td><h4><?php echo __('Layout','product-questions-answers-for-woocommerce'); ?>: </h4></td>
 					<td><select name="paging_type">
-					    	<option value="normal" <?php if($pagingType == "normal") { ?> selected <?php }?>><?php echo __('Normal','ets_q_n_a');?></option>
-					    	<option value="accordion"  <?php if($pagingType == "accordion") { ?> selected <?php }?>><?php echo __('Accordion','ets_q_n_a');?></option>
+					    	<option value="normal" <?php if($pagingType == "normal") { ?> selected <?php }?>><?php echo __('Normal','product-questions-answers-for-woocommerce');?></option>
+					    	<option value="accordion"  <?php if($pagingType == "accordion") { ?> selected <?php }?>><?php echo __('Accordion','product-questions-answers-for-woocommerce');?></option>
 						</select>
 					</td>
 				</tr>
 				<tr>
-					<td><h4><?php echo __('Auto Approve','ets_q_n_a'); ?>: </h4></td>
+					<td><h4><?php echo __('Auto Approve','product-questions-answers-for-woocommerce'); ?>: </h4></td>
 					<td><input type="checkbox" name="ets_qa_approve" value="yes" <?php if(isset($aprValue) && $aprValue == 'yes'){ echo "checked"; } else { '' ; }?>></td>
 				</tr> 
 				<tr><td></td>
-					<td><button type="submit" name="ets_load_more" class="button button-primary button-large"><?php echo __('Submit',"ets_q_n_a"); ?></button>
+					<td><button type="submit" name="ets_load_more" class="button button-primary button-large"><?php echo __('Submit',"product-questions-answers-for-woocommerce"); ?></button>
 				</tr>
 			</table>
 		</form> 
@@ -173,7 +173,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
  	public function product_tab_admin_qa( $tabs ){
  
 		$tabs['admin_answer'] = array(
-			'label'    		=> __('Q & A','ets_q_n_a'),
+			'label'    		=> __('Q & A','product-questions-answers-for-woocommerce'),
 			'target'   		=> 'ets_product_data', 
 			'priority' 		=> 100,  
 			'id'			=> 'ets_question',
@@ -264,7 +264,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 								'id'    	  =>  "ets_question[$key]",  
 								'name'		  =>  "ets_question[$key]",
 								'value'       =>  $value['question'],
-								'label'       =>  __('Question','ets_q_n_a').': '  
+								'label'       =>  __('Question','product-questions-answers-for-woocommerce').': '  
 							) 
 						);
 
@@ -273,7 +273,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 								'id'		   =>  "ets_answer[$key]",
 								'name'		   =>  "ets_answer[$key]",
 								'value'        =>  $value['answer'], 
-								'label'        =>  __('Answer','ets_q_n_a').': ' 
+								'label'        =>  __('Answer','product-questions-answers-for-woocommerce').': ' 
 							) 
 						);	
 
@@ -285,7 +285,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 								'value'	=> ((isset($value['approve']) && $value['approve'] =='yes') || !isset($value['approve']) ) ? 'yes' :'no',
 								'cbvalue' => 'yes',
 								
-	 							'label'   =>  __('Approve','ets_q_n_a').': ',
+	 							'label'   =>  __('Approve','product-questions-answers-for-woocommerce').': ',
 							)
 						);
 							
@@ -325,7 +325,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 								array(  
 									'name'		  => 'ets_first_question',
 									'value'       => '',
-									'label'       => __('Question','ets_q_n_a').' : ',
+									'label'       => __('Question','product-questions-answers-for-woocommerce').' : ',
 									'desc_tip'    => true, 
 									'id'		  => 'ets_question_data'	 
 								) 
@@ -334,7 +334,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 								array( 
 									'name'		  => 'ets_first_answer',
 									'value'       =>  '',
-									'label'       => __('Answer','ets_q_n_a').' : ',
+									'label'       => __('Answer','product-questions-answers-for-woocommerce').' : ',
 									'desc_tip'    => true, 	
 									'id'		  => 'ets_answer_data' 
 								) 
@@ -351,7 +351,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 		 		</ul> 
 		 		<input type="hidden" name="ets-new-question-Answer-count" id="ets-new-question-Answer-count" value=""> 
 				<a href="#" type="submit" name="ets-add-new-qa" class="ets-add-new-qa ">+<?php 
-					echo apply_filters('wc_add_new_qa_label', __('Add New',"ets_q_n_a"));
+					echo apply_filters('wc_add_new_qa_label', __('Add New',"product-questions-answers-for-woocommerce"));
 					?></a>
 
 				
@@ -495,7 +495,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 				if ( $before_save && !empty(trim($value['answer'])) && !empty(trim($value['user_email'])) && (trim($value['answer']) != trim($before_save[$key]['answer']) && !empty( trim( $before_save[$key]['answer'] )  ) ) )
 				{
 
-			 		$subject =apply_filters("wc_qa_answer_updated_mail_subject" ,__("Answer to Your Question was Updated",'ets_q_n_a'). ': ' . get_bloginfo('name'));
+			 		$subject =apply_filters("wc_qa_answer_updated_mail_subject" ,__("Answer to Your Question was Updated",'product-questions-answers-for-woocommerce'). ': ' . get_bloginfo('name'));
 			 		$message = "Dear " . $userName . ",<br><br>";
 			 		$message .= "<a href='$site_url'>" . $site_name . "</a> updated an answer to your question on the product <a href='$url'> " . $productTitle ."</a>:  <br><div style='background-color: #FFF8DC;border-left: 2px solid #ffeb8e;padding: 10px;margin-top:10px;'>". $answers ."</div>";
 
@@ -505,7 +505,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 				 
 				// First time answer    
 				} elseif ( $before_save && empty( trim( $before_save[$key]['answer'] ) ) && !empty( trim( $value['answer'] ) )  && !empty(trim($value['user_email'])) ) {  
-					$subject = __("Your Question was Answered",'ets_q_n_a'). ': ' . get_bloginfo('name');
+					$subject = __("Your Question was Answered",'product-questions-answers-for-woocommerce'). ': ' . get_bloginfo('name');
 			 		$subject = apply_filters("wc_qa_new_answer_mail_subject", $subject);
 			 		$message = "Dear " . $userName . ",<br><br>";
 			 		$message .= "<a href='$site_url'>" . $site_name . "</a> added an answer on the product <a href='$url'> " . $productTitle ."</a>:  <br><div style='background-color: #FFF8DC;border-left: 2px solid #ffeb8e;padding: 10px;margin-top:10px;'>". $answers ."</div>";
@@ -618,7 +618,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 		if( !wp_verify_nonce($_POST['addNewQaNonce'],'ets-product-add-new-qa')){
 			$response = array( 
 				'status'		=>  0,
-				'error'			=>  __("Access not allowed",'ets_q_n_a').'.'
+				'error'			=>  __("Access not allowed",'product-questions-answers-for-woocommerce').'.'
 			);
 			
 			echo json_encode($response);
@@ -634,7 +634,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 			array(  
 				'name'		  =>    "ets_new_question[$count]",
 				'value'       =>    '',
-				'label'       =>     __('Question','ets_q_n_a').": ",
+				'label'       =>     __('Question','product-questions-answers-for-woocommerce').": ",
 				'desc_tip'    =>    true,  	 
 			) 
 		);
@@ -643,7 +643,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 			array( 
 				'name'		  =>   "ets_new_answer[$count]",
 				'value'       =>    '', 
-				'label'       =>     __('Answer','ets_q_n_a').': ',
+				'label'       =>     __('Answer','product-questions-answers-for-woocommerce').': ',
 				'desc_tip'    =>     true,
 			) 
 		); 
@@ -652,7 +652,7 @@ class ETS_WOO_PRODUCT_ADMIN_QUESTION_ANSWER
 			array( 
 				'name'		        =>  "ets_admin_apv[$count]",
 				'class'				=>   "ets_admin_apv",		
-				'label'             =>   __('Approve','ets_q_n_a').': ' ,
+				'label'             =>   __('Approve','product-questions-answers-for-woocommerce').': ' ,
 				'value'	            => 'yes',
 				'cbvalue'           => 'yes',
 			)

--- a/includes/ets_user_qa_function.php
+++ b/includes/ets_user_qa_function.php
@@ -38,7 +38,7 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 	public function question_tab( $tabs ) { 
 	     
 	    $tabs['ask'] = array(
-		    'title'     =>  apply_filters("wc_qa_tab_name" , __( __("Q & A",'ets_q_n_a'), 'woocommerce')),
+		    'title'     =>  apply_filters("wc_qa_tab_name" , __( __("Q & A",'product-questions-answers-for-woocommerce'), 'woocommerce')),
 		    'priority'  => 50,
 		    'callback'  => array($this , 'ets_ask_qustion_tab')
     	);  
@@ -53,7 +53,7 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 
 			$response = array(	
 				'status' => 0, 
-				'message'	=> __('Access not allowed','ets_q_n_a').'.'  
+				'message'	=> __('Access not allowed','product-questions-answers-for-woocommerce').'.'  
 			); 
 			
 			echo json_encode($response);
@@ -62,7 +62,7 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 		if ( !is_user_logged_in() ) { 
 			echo json_encode( array( 
 						'status' =>  0,
-						'message'	=> apply_filters("wc_qa_not_logged_in_message", __('You are not logged in','ets_q_n_a').'.'
+						'message'	=> apply_filters("wc_qa_not_logged_in_message", __('You are not logged in','product-questions-answers-for-woocommerce').'.'
 					)) 
 			);
 			die; 
@@ -110,7 +110,7 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 			$response = array(
 				'status' 		=> 1, 
 				'productId' 	=> $productId,
-				'message' 		=> __("Question submitted successfully",'ets_q_n_a').'.',
+				'message' 		=> __("Question submitted successfully",'product-questions-answers-for-woocommerce').'.',
 				'ets_get_question_data'	=> $result 
 			);   
 			echo json_encode($response);
@@ -120,7 +120,7 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 			
 			$response = array(	
 				'status' 	=> 0, 
-				"message"	=> __("Please enter your question", 'ets_q_n_a').'.',  
+				"message"	=> __("Please enter your question", 'product-questions-answers-for-woocommerce').'.',  
 			); 
 			echo json_encode($response);
 			
@@ -167,14 +167,14 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 			$uesrEmail = $user->user_email;
 		 	?>
 			<form action="#" method="post"  id="ets-qus-form" name="form">  
-				<textarea id="ques-text-ar" cols="45" rows="3" id="name" class="ets-qa-textarea"   name="question" value="" placeholder="<?php echo __('Enter your question here','ets_q_n_a') ?>..." height= "75px" ></textarea>
+				<textarea id="ques-text-ar" cols="45" rows="3" id="name" class="ets-qa-textarea"   name="question" value="" placeholder="<?php echo __('Enter your question here','product-questions-answers-for-woocommerce') ?>..." height= "75px" ></textarea>
 				<input type="hidden" id="useremail" class="productId" name="usermail" value="<?php echo $uesrEmail ?>">
 				<input type="hidden" id="custId" class="productId" name="product_id" value="<?php echo $productId ?>">
 				<input type="hidden" id="productlength" class="productlength" name="Product_Qa_Length" value="<?php echo $productQaLength ?>">  
 				<input type="hidden" id="producttitle" name="ets_Product_Title" value="<?php echo $productTitle ?>">
 				<div class="ets-display-message"><p></p></div>
 				<div class="ets-dis-message-error"><p></p></div>
-				<button id="ets-submit" type="submit" name="submit" class="btn btn-info" ><?php echo __('Submit','ets_q_n_a'); ?></button> 
+				<button id="ets-submit" type="submit" name="submit" class="btn btn-info" ><?php echo __('Submit','product-questions-answers-for-woocommerce'); ?></button> 
 			</form>
 			<div id="ets_product_qa_length"><p></p></div>   
 			<?php 	
@@ -190,7 +190,8 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 				global $wp;
 
 				printf(
-					__( 'Please <a href="%s">login</a> to post questions', 'ets_q_n_a' ),
+					/* translators: login URL */
+					__( 'Please <a href="%s">login</a> to post questions', 'product-questions-answers-for-woocommerce' ),
 					apply_filters( 'wc_add_qa_login_url', wp_login_url(home_url( $wp->request )) )
 				);
 			?>
@@ -217,7 +218,7 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 
 			if($loadMoreButton == 1) { 
 				if(empty($loadMoreButtonName)){
-					$loadMoreButtonName = __("Load More",'ets_q_n_a');
+					$loadMoreButtonName = __("Load More",'product-questions-answers-for-woocommerce');
 					update_option( 'ets_load_more_button_name', $loadMoreButtonName );
 				}  
 
@@ -241,22 +242,22 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 
 							?>
 							<div class="ets-accordion">
-								<span class="que-content"><b><?php echo __('Question','ets_q_n_a') ?>:</b></span>
+								<span class="que-content"><b><?php echo __('Question','product-questions-answers-for-woocommerce') ?>:</b></span>
 								<span class="que-content-des"><?php echo $value['question'];?></span>
 								<h6><?php echo $value['user_name']. "<br>";?><?php echo $value['date']; ?></h6>
 							</div>
 							<div class="ets-panel">
 								<?php 
 								if(!empty($value['answer'])){?>
-									<span class="ans-content"><b><?php echo __('Answer','ets_q_n_a') ?>:</b>
+									<span class="ans-content"><b><?php echo __('Answer','product-questions-answers-for-woocommerce') ?>:</b>
 									</span>
 									<span class="ans-content-des"><?php echo $value['answer'];?>
 									</span>
 								 
 							<?php 
 								} else { ?>
-								<span class="ans-content"><b><?php echo __('Answer','ets_q_n_a') ?>.</b></span>
-								<span class="ans-content-des"><i><?php echo __("Answer awaiting",'ets_q_n_a');?>...</i>
+								<span class="ans-content"><b><?php echo __('Answer','product-questions-answers-for-woocommerce') ?>.</b></span>
+								<span class="ans-content-des"><i><?php echo __("Answer awaiting",'product-questions-answers-for-woocommerce');?>...</i>
 								</span>
 								<?php
 							}?>
@@ -285,7 +286,7 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 							
 							?>
 							<tr class="ets-question-top">
-								<td class="ets-question-title"><p><?php echo __('Question','ets_q_n_a'); ?>:</p></td>
+								<td class="ets-question-title"><p><?php echo __('Question','product-questions-answers-for-woocommerce'); ?>:</p></td>
 								<td class="ets-question-description"><p><?php echo $value['question'];?></p></td> 
 								<td class="ets-cont-right"><h6 class="user-name"><?php echo $value['user_name'] . "<br>";    
 								echo ($value['date']); ?></h6></td>
@@ -294,15 +295,15 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 							if(!empty($value['answer'])){
 							?>
 								<tr>
-									<td class="ets-question-title"><p><?php echo __('Answer','ets_q_n_a'); ?>:</p></td>
+									<td class="ets-question-title"><p><?php echo __('Answer','product-questions-answers-for-woocommerce'); ?>:</p></td>
 									<td colspan="2"><p> <?php echo $value['answer'];?></p></td> 
 								</tr> 
 							<?php 
 							} else {
 							?>
 								<tr>
-									<td class="ets-question-title"><p><?php echo __('Answer:','ets_q_n_a'); ?></p></td>
-									<td colspan="2" class="ets-no-answer" ><h6><p><i><?php echo __("Answer awaiting",'ets_q_n_a');?>...</i></p></h6></td>	
+									<td class="ets-question-title"><p><?php echo __('Answer:','product-questions-answers-for-woocommerce'); ?></p></td>
+									<td colspan="2" class="ets-no-answer" ><h6><p><i><?php echo __("Answer awaiting",'product-questions-answers-for-woocommerce');?>...</i></p></h6></td>	
 								</tr> 
 								<?php
 							}
@@ -332,7 +333,7 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 					foreach ($etsGetQuestion as $key => $value) {
 						?> 
 						<tr class="ets-question-top">
-								<td class="ets-question-title"><p><?php echo __('Question','ets_q_n_a'); ?>:</p></td>
+								<td class="ets-question-title"><p><?php echo __('Question','product-questions-answers-for-woocommerce'); ?>:</p></td>
 								<td class="ets-question-description"><p><?php echo $value['question'];?></p></td> 
 								<td class="ets-cont-right"><h6 class="user-name"><?php echo $value['user_name'] . "<br>";    
 								echo ($value['date']);
@@ -342,14 +343,14 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 						<?php 
 						if(!empty($value['answer'])){?>
 							<tr>
-								<td class="ets-question-title"><p><?php echo __('Answer','ets_q_n_a'); ?>:</p></td>
+								<td class="ets-question-title"><p><?php echo __('Answer','product-questions-answers-for-woocommerce'); ?>:</p></td>
 								<td colspan="2"><p> <?php echo $value['answer'];?></p></td> 
 							</tr> 
 							<?php 
 						} else { ?>
 							<tr>
-								<td class="ets-question-title"><p><?php echo __('Answer','ets_q_n_a'); ?>:</p></td>
-								<td colspan="2" class="ets-no-answer"><h6><p><i><?php echo __("Answer awaiting",'ets_q_n_a');?>...</i></p></h6></td>	
+								<td class="ets-question-title"><p><?php echo __('Answer','product-questions-answers-for-woocommerce'); ?>:</p></td>
+								<td colspan="2" class="ets-no-answer"><h6><p><i><?php echo __("Answer awaiting",'product-questions-answers-for-woocommerce');?>...</i></p></h6></td>	
 							</tr> 
 							<?php
 						}
@@ -417,22 +418,22 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 						
 					?>
 					<div class="ets-accordion">
-						<span class="que-content ans-content"><b><?php echo __('Question','ets_q_n_a'); ?>:</b></span>
+						<span class="que-content ans-content"><b><?php echo __('Question','product-questions-answers-for-woocommerce'); ?>:</b></span>
 						<span class="que-content-des"><?php echo $value['question'];?></span>
 						<h6><?php echo $value['user_name']. "<br>";?><?php echo $value['date'];?></h6>
 					</div>
 					<div class="ets-panel">
 						<?php 
 						if(!empty($value['answer'])){?>
-							<span class="ans-content"><b><?php echo __('Answer','ets_q_n_a'); ?>:</b>
+							<span class="ans-content"><b><?php echo __('Answer','product-questions-answers-for-woocommerce'); ?>:</b>
 							</span>
 							<span class="ans-content-des"><?php echo $value['answer'];?>
 							</span>
 						 
 							<?php 
 						} else { ?>
-							<span class="ans-content"><b><?php echo __('Answer:','ets_q_n_a'); ?></b></span>
-							<span class="ans-content-des"><i><?php echo __("Answer awaiting",'ets_q_n_a');?>...</i>
+							<span class="ans-content"><b><?php echo __('Answer:','product-questions-answers-for-woocommerce'); ?></b></span>
+							<span class="ans-content-des"><i><?php echo __("Answer awaiting",'product-questions-answers-for-woocommerce');?>...</i>
 							</span> 
 							<?php
 						} ?>
@@ -457,7 +458,7 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 				 	
 					?> 
 					<tr class="ets-question-top">
-						<td class="ets-question-title"><p><?php echo __("Question","ets_q_n_a");?>.</p></td>
+						<td class="ets-question-title"><p><?php echo __("Question","product-questions-answers-for-woocommerce");?>.</p></td>
 						<td class="ets-question-description"><p><?php echo $value['question'];?></p></td> 
 						<td class="ets-cont-right"><h6 class="user-name"><?php echo $value['user_name'] . "<br>";    
 							echo ($value['date']); 
@@ -467,14 +468,14 @@ class ETS_WOO_PRODUCT_USER_QUESTION_ANSWER
 					<?php 
 					if(!empty($value['answer'])){?>
 						<tr>
-							<td class="ets-question-title"><p><?php echo __("Answer","ets_q_n_a");?>:</p></td>
+							<td class="ets-question-title"><p><?php echo __("Answer","product-questions-answers-for-woocommerce");?>:</p></td>
 							<td colspan="2"><p> <?php echo $value['answer'];?></p></td> 
 						</tr> 
 						<?php 
 					} else { ?>
 						<tr>
-							<td class="ets-question-title"><p><?php echo __("Answer:","ets_q_n_a");?></p></td>
-							<td colspan="2" class="ets-no-answer"><h6><p> <i><?php echo __("Answer awaiting",'ets_q_n_a');?>...</i></p></h6></td>	
+							<td class="ets-question-title"><p><?php echo __("Answer:","product-questions-answers-for-woocommerce");?></p></td>
+							<td colspan="2" class="ets-no-answer"><h6><p> <i><?php echo __("Answer awaiting",'product-questions-answers-for-woocommerce');?>...</i></p></h6></td>	
 						</tr> 
 						<?php
 					}

--- a/languages/product-questions-answers-for-woocommerce.pot
+++ b/languages/product-questions-answers-for-woocommerce.pot
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 ExpressTech Software Solutions Pvt. Ltd.
+# Copyright (C) 2024 ExpressTech Software Solutions Pvt. Ltd.
 # This file is distributed under the same license as the Product Questions & Answers for WooCommerce plugin.
 msgid ""
 msgstr ""
@@ -9,10 +9,10 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-02-17T19:55:06+05:30\n"
+"POT-Creation-Date: 2024-02-08T00:17:53+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.5.0\n"
-"X-Domain: ets_q_n_a\n"
+"X-Generator: WP-CLI 2.8.1\n"
+"X-Domain: product-questions-answers-for-woocommerce\n"
 
 #. Plugin Name of the plugin
 msgid "Product Questions & Answers for WooCommerce"
@@ -45,7 +45,7 @@ msgstr ""
 #: includes/ets_admin_qa_function.php:108
 #: includes/ets_admin_qa_function.php:116
 #: includes/ets_admin_qa_function.php:135
-#: includes/ets_user_qa_function.php:220
+#: includes/ets_user_qa_function.php:221
 msgid "Load More"
 msgstr ""
 
@@ -90,24 +90,24 @@ msgstr ""
 #: includes/ets_admin_qa_function.php:267
 #: includes/ets_admin_qa_function.php:328
 #: includes/ets_admin_qa_function.php:637
-#: includes/ets_user_qa_function.php:244
-#: includes/ets_user_qa_function.php:288
-#: includes/ets_user_qa_function.php:335
-#: includes/ets_user_qa_function.php:420
-#: includes/ets_user_qa_function.php:460
+#: includes/ets_user_qa_function.php:245
+#: includes/ets_user_qa_function.php:289
+#: includes/ets_user_qa_function.php:336
+#: includes/ets_user_qa_function.php:421
+#: includes/ets_user_qa_function.php:461
 msgid "Question"
 msgstr ""
 
 #: includes/ets_admin_qa_function.php:276
 #: includes/ets_admin_qa_function.php:337
 #: includes/ets_admin_qa_function.php:646
-#: includes/ets_user_qa_function.php:251
-#: includes/ets_user_qa_function.php:258
-#: includes/ets_user_qa_function.php:297
-#: includes/ets_user_qa_function.php:345
-#: includes/ets_user_qa_function.php:351
-#: includes/ets_user_qa_function.php:427
-#: includes/ets_user_qa_function.php:470
+#: includes/ets_user_qa_function.php:252
+#: includes/ets_user_qa_function.php:259
+#: includes/ets_user_qa_function.php:298
+#: includes/ets_user_qa_function.php:346
+#: includes/ets_user_qa_function.php:352
+#: includes/ets_user_qa_function.php:428
+#: includes/ets_user_qa_function.php:471
 msgid "Answer"
 msgstr ""
 
@@ -144,20 +144,21 @@ msgstr ""
 msgid "Enter your question here"
 msgstr ""
 
-#: includes/ets_user_qa_function.php:193
+#. translators: login URL
+#: includes/ets_user_qa_function.php:194
 msgid "Please <a href=\"%s\">login</a> to post questions"
 msgstr ""
 
-#: includes/ets_user_qa_function.php:259
-#: includes/ets_user_qa_function.php:305
-#: includes/ets_user_qa_function.php:352
-#: includes/ets_user_qa_function.php:435
-#: includes/ets_user_qa_function.php:477
+#: includes/ets_user_qa_function.php:260
+#: includes/ets_user_qa_function.php:306
+#: includes/ets_user_qa_function.php:353
+#: includes/ets_user_qa_function.php:436
+#: includes/ets_user_qa_function.php:478
 msgid "Answer awaiting"
 msgstr ""
 
-#: includes/ets_user_qa_function.php:304
-#: includes/ets_user_qa_function.php:434
-#: includes/ets_user_qa_function.php:476
+#: includes/ets_user_qa_function.php:305
+#: includes/ets_user_qa_function.php:435
+#: includes/ets_user_qa_function.php:477
 msgid "Answer:"
 msgstr ""


### PR DESCRIPTION
This PR apply the following changes:

- Updates text domain from `ets_q_n_a` to `product-questions-answers-for-woocommerce` to comply with the standards ([see](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#:~:text=The%20text%20domain%20must,of%20the%20plugin)).
- Adds translators comment to string with placeholder ([see](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#descriptions))
- Renames the translation template to comply with the standards

Closes: #27